### PR TITLE
Documentation clarity & less docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM adoptopenjdk/openjdk11:latest
 
-RUN useradd --home /home/pleo --shell /bin/false pleo &&\
-    apt-get update && \
+RUN apt-get update && \
     apt-get install -y sqlite3
-
-USER pleo
 
 COPY . /anteus
 WORKDIR /anteus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM adoptopenjdk/openjdk11:latest
 
-# Install dependencies
-RUN apt-get update && apt-get install -y sqlite3
+RUN useradd --home /home/pleo --shell /bin/false pleo &&\
+    apt-get update && \
+    apt-get install -y sqlite3
 
-# Expose the app port.
+USER pleo
+
+COPY . /anteus
+WORKDIR /anteus
+
 EXPOSE 7000
-
-# Setup app user.
-RUN useradd --home /home/pleo --shell /bin/false pleo
-
-# Switch to app workdir.
-WORKDIR /home/pleo
-
-# Copy over source code.
-COPY . /home/pleo
-
 # When the container starts: build, test and run the app.
 CMD ./gradlew build && ./gradlew test && ./gradlew run

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requirements:
 
 ### Running
 
-There are 2 options for running anteus. You either need libsqlite3 or docker. Docker is easier but more invasive to setup.
+There are 2 options for running Anteus. You either need libsqlite3 or docker. Docker is easier but more invasive to setup.
 
 *Running Natively*
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,78 @@
 ## Antaeus
 
-Antaeus (/ænˈtiːəs/), in Greek mythology, a giant of Libya, the son of the sea god Poseidon and the Earth goddess Gaia. He compelled all strangers who were passing through the country to wrestle with him. Whenever Antaeus touched the Earth (his mother), his strength was renewed, so that even if thrown to the ground, he was invincible. Heracles, in combat with him, discovered the source of his strength and, lifting him up from Earth, crushed him to death.
+> Antaeus (/ænˈtiːəs/), in Greek mythology, a giant of Libya, the son of the sea god Poseidon and the Earth goddess Gaia. He compelled all strangers who were passing through the country to wrestle with him. Whenever Antaeus touched the Earth (his mother), his strength was renewed, so that even if thrown to the ground, he was invincible. Heracles, in combat with him, discovered the source of his strength and, lifting him up from Earth, crushed him to death.
 
 Welcome to our challenge.
 
 ## The challenge
 
-As most "Software as a Service" (SaaS) companies, Pleo needs to charge a subscription fee every month. Our database contains a few invoices for the different markets in which we operate. Your task is to build the logic that will pay those invoices on the first of the month. While this may seem simple, there is space for some decisions to be taken and you will be expected to justify them.
-
-### Structure
-The code given is structured as follows. Feel free however to modify the structure to fit your needs.
-```
-├── pleo-antaeus-app
-|
-|       Packages containing the main() application. 
-|       This is where all the dependencies are instantiated.
-|
-├── pleo-antaeus-core
-|
-|       This is where you will introduce most of your new code.
-|       Pay attention to the PaymentProvider and BillingService class.
-|
-├── pleo-antaeus-data
-|
-|       Module interfacing with the database. Contains the models, mappings and access layer.
-|
-├── pleo-antaeus-models
-|
-|       Definition of models used throughout the application.
-|
-├── pleo-antaeus-rest
-|
-|        Entry point for REST API. This is where the routes are defined.
-└──
-```
+As most "Software as a Service" (SaaS) companies, Pleo needs to charge a subscription fee every month. Our database contains a few invoices for the different markets in which we operate. Your task is to build the logic that will schedule payment of those invoices on the first of the month. While this may seem simple, there is space for some decisions to be taken and you will be expected to justify them.
 
 ## Instructions
-Fork this repo with your solution. We want to see your progression through commits (don’t commit the entire solution in 1 step) and don't forget to create a README.md to explain your thought process.
+
+Fork this repo with your solution. Ideally, we'd like to see your progression through commits, and don't forget to update the README.md to explain your thought process.
 
 Please let us know how long the challenge takes you. We're not looking for how speedy or lengthy you are. It's just really to give us a clearer idea of what you've produced in the time you decided to take. Feel free to go as big or as small as you want.
 
 Happy hacking 😁!
 
-## How to run
+## Developing
+
+Requirements:
+- >= Java 11 environment
+- Ideally: a java IDE but if you're wild notepad does the job
+
+### Building
+
+```
+./gradlew build
+```
+
+### Running
+
+There are 2 options for running anteus. You either need libsqlite3 or docker. Docker is easier but more invasive to setup.
+
+*Running Natively*
+
+Native java with sqlite (requires libsqlite3):
+
+If you use homebrew on MacOS `brew install sqlite`.
+
+```
+./gradlew run
+```
+
+*Running through docker*
+
+Install docker for your platform
+
 ```
 ./docker-start.sh
 ```
 
-## Libraries currently in use
+### App Structure
+The code given is structured as follows. Feel free however to modify the structure to fit your needs.
+```
+├── pleo-antaeus-app
+|       main() & dependency injection initialization
+|
+├── pleo-antaeus-core
+|       This is probably where you will introduce most of your new code.
+|       Pay attention to the PaymentProvider and BillingService class.
+|
+├── pleo-antaeus-data
+|       Module interfacing with the database. Contains the database models, mappings and access layer.
+|
+├── pleo-antaeus-models
+|       Definition of the "rest api" models used throughout the application.
+|
+├── pleo-antaeus-rest
+|        Entry point for REST API. This is where the routes are defined.
+└──
+```
+
+### Main Libraries currently in use
+* [Sqlite3](https://sqlite.org/index.html) - Database storage
 * [Exposed](https://github.com/JetBrains/Exposed) - DSL for type-safe SQL
 * [Javalin](https://javalin.io/) - Simple web framework (for REST)
 * [kotlin-logging](https://github.com/MicroUtils/kotlin-logging) - Simple logging framework for Kotlin

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Happy hacking 😁!
 ## Developing
 
 Requirements:
-- >= Java 11 environment
+- \>= Java 11 environment
 - Ideally: a java IDE but if you're wild notepad does the job
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you use homebrew on MacOS `brew install sqlite`.
 Install docker for your platform
 
 ```
-./docker-start.sh
+make docker-run
 ```
 
 ### App Structure

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Antaeus
 
-> Antaeus (/ænˈtiːəs/), in Greek mythology, a giant of Libya, the son of the sea god Poseidon and the Earth goddess Gaia. He compelled all strangers who were passing through the country to wrestle with him. Whenever Antaeus touched the Earth (his mother), his strength was renewed, so that even if thrown to the ground, he was invincible. Heracles, in combat with him, discovered the source of his strength and, lifting him up from Earth, crushed him to death.
+Antaeus (/ænˈtiːəs/), in Greek mythology, a giant of Libya, the son of the sea god Poseidon and the Earth goddess Gaia. He compelled all strangers who were passing through the country to wrestle with him. Whenever Antaeus touched the Earth (his mother), his strength was renewed, so that even if thrown to the ground, he was invincible. Heracles, in combat with him, discovered the source of his strength and, lifting him up from Earth, crushed him to death.
 
 Welcome to our challenge.
 
@@ -14,13 +14,10 @@ Fork this repo with your solution. Ideally, we'd like to see your progression th
 
 Please let us know how long the challenge takes you. We're not looking for how speedy or lengthy you are. It's just really to give us a clearer idea of what you've produced in the time you decided to take. Feel free to go as big or as small as you want.
 
-Happy hacking 😁!
-
 ## Developing
 
 Requirements:
 - \>= Java 11 environment
-- Ideally: a java IDE but if you're wild notepad does the job
 
 ### Building
 
@@ -30,7 +27,16 @@ Requirements:
 
 ### Running
 
-There are 2 options for running Anteus. You either need libsqlite3 or docker. Docker is easier but more invasive to setup.
+There are 2 options for running Anteus. You either need libsqlite3 or docker. Docker is easier but requires some docker knowledge. We do recommend docker though.
+
+
+*Running through docker*
+
+Install docker for your platform
+
+```
+make docker-run
+```
 
 *Running Natively*
 
@@ -42,19 +48,12 @@ If you use homebrew on MacOS `brew install sqlite`.
 ./gradlew run
 ```
 
-*Running through docker*
-
-Install docker for your platform
-
-```
-make docker-run
-```
 
 ### App Structure
 The code given is structured as follows. Feel free however to modify the structure to fit your needs.
 ```
 ├── pleo-antaeus-app
-|       main() & dependency injection initialization
+|       main() & initialization
 |
 ├── pleo-antaeus-core
 |       This is probably where you will introduce most of your new code.
@@ -71,10 +70,12 @@ The code given is structured as follows. Feel free however to modify the structu
 └──
 ```
 
-### Main Libraries currently in use
-* [Sqlite3](https://sqlite.org/index.html) - Database storage
+### Main Libraries and dependencies
 * [Exposed](https://github.com/JetBrains/Exposed) - DSL for type-safe SQL
 * [Javalin](https://javalin.io/) - Simple web framework (for REST)
 * [kotlin-logging](https://github.com/MicroUtils/kotlin-logging) - Simple logging framework for Kotlin
 * [JUnit 5](https://junit.org/junit5/) - Testing framework
 * [Mockk](https://mockk.io/) - Mocking library
+* [Sqlite3](https://sqlite.org/index.html) - Database storage engine
+
+Happy hacking 😁!

--- a/docker-clean.sh
+++ b/docker-clean.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
+set -x
+
 # Remove the docker volume that stores cached build artifacts.
 # This also stops and removes any container using the volume.
 echo 'Clearing build cache: '
 docker volume remove -f pleo-antaeus-build-cache
-echo
 
+echo 'Cleaning docker images'
 # Remove all pleo-antaeus images.
 docker images --quiet --filter="reference=pleo-antaeus:*" | \
  while read image; do

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 # Create a new image version with latest code changes.
 docker build . --tag pleo-antaeus
 
@@ -9,4 +11,6 @@ docker run \
   --rm \
   --interactive \
   --tty \
+  # This volume is only there so incremental builds are way faster
+  --volume pleo-antaeus-build-cache:/root/.gradle \
   pleo-antaeus

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -5,10 +5,9 @@ docker build . --tag pleo-antaeus
 
 # Build the code.
 docker run \
-  --name pleo-anteus-app \
   --publish 7000:7000 \
   --rm \
   --interactive \
   --tty \
-  --volume pleo-antaeus-build-cache:/home/pleo/.gradle \
+  --volume pleo-antaeus-docker-build-cache:/home/pleo/.gradle \
   pleo-antaeus

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -9,5 +9,4 @@ docker run \
   --rm \
   --interactive \
   --tty \
-  --volume pleo-antaeus-docker-build-cache:/home/pleo/.gradle \
   pleo-antaeus


### PR DESCRIPTION
Reduced the number of docker commands to make it a little faster, it generates less layers and rebuilds faster that way.

I also rephrased part of the readme and added the instructions on how to run it without docker since people that do not know docker or kotlin or jvm world seems to pass a lot of time. Instructions on how to build/run also are helpful.