### PR TITLE
Fix copy-paste typo in InvoiceServiceTest

### DIFF
--- a/pleo-antaeus-core/src/test/kotlin/io/pleo/antaeus/core/services/InvoiceServiceTest.kt
+++ b/pleo-antaeus-core/src/test/kotlin/io/pleo/antaeus/core/services/InvoiceServiceTest.kt
@@ -15,7 +15,7 @@ class InvoiceServiceTest {
     private val invoiceService = InvoiceService(dal = dal)
 
     @Test
-    fun `will throw if customer is not found`() {
+    fun `will throw if invoice is not found`() {
         assertThrows<InvoiceNotFoundException> {
             invoiceService.fetch(404)
         }


### PR DESCRIPTION
Replace "customer" for "invoice" in the invoice service test.