### PR TITLE
Update docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you use homebrew on MacOS `brew install sqlite`.
 Install docker for your platform
 
 ```
-docker build -t antaeus
+docker build . -t antaeus
 docker run antaeus
 ```
 


### PR DESCRIPTION
Updated the docker build command since the one in the README didn't work with me:
```
"docker build" requires exactly 1 argument.
```